### PR TITLE
Bump requirement for minimum Symfony version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "php": "^7.0",
     "gocardless/enterprise": "^6.0",
     "stof/doctrine-extensions-bundle": "*",
-    "symfony/symfony": "^2.8|^3.0|^4.0"
+    "symfony/symfony": "^3.4.26|^4.0|^5.0"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "*",
@@ -37,8 +37,8 @@
     "phpstan/phpstan": "^0.11",
     "phpstan/phpstan-phpunit": "^0.11",
     "phpunit/phpunit": "~7.5",
-    "sensiolabs/security-checker": "^5.0",
-    "symfony/phpunit-bridge": "^2.8|^3.0|^4.0"
+    "sensiolabs/security-checker": "^6.0",
+    "symfony/phpunit-bridge": "^3.0|^4.0|^5.0"
   },
 
   "scripts": {


### PR DESCRIPTION
This PR covers CVE-2019-10909. It also allows Symfony 5 to be used.