### PR TITLE
[COL-793] Update the isActive method, add the mandate state enum

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -53,7 +53,7 @@ return \PhpCsFixer\Config::create()
             'no_trailing_comma_in_singleline_array' => true,
             'no_unneeded_control_parentheses' => true,
             'no_unneeded_curly_braces' => true,
-            'no_unneeded_final_method' => true,
+            'no_unneeded_final_method' => false,
             'no_unreachable_default_argument_value' => false,
             'no_unused_imports' => true,
             'no_useless_else' => true,

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,8 +51,8 @@ install:
     elif [ "$DEPENDENCIES" = "low" ]; then
       composer update -n --prefer-dist --prefer-lowest;
     elif [ "$SYMFONY_VERSION" != "" ]; then
-      composer remove symfony/symfony --dev &&
-      composer require symfony/symfony:"${SYMFONY_VERSION}" --dev --no-update;
+      composer remove symfony/symfony &&
+      composer require symfony/symfony:"${SYMFONY_VERSION}" --no-update;
     else
       composer update -n --prefer-dist;
     fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ before_install:
 
 install:
   - if [ "$(phpenv version-name)" != "$LATEST_PHP_VERSION" ]; then
-      composer remove friendsofphp/php-cs-fixer phpstan/phpstan --dev;
+      composer remove friendsofphp/php-cs-fixer phpstan/phpstan-phpunit phpstan/phpstan --dev;
     fi
   - if [ "$DEPENDENCIES" = "beta" ]; then
       composer config minimum-stability beta;

--- a/src/Entity/Mandate.php
+++ b/src/Entity/Mandate.php
@@ -2,6 +2,8 @@
 
 namespace Lendable\GoCardlessEnterpriseBundle\Entity;
 
+use Lendable\GoCardlessEnterpriseBundle\Enum\MandateState;
+
 class Mandate extends \Lendable\GoCardlessEnterprise\Model\Mandate
 {
     /**
@@ -67,6 +69,6 @@ class Mandate extends \Lendable\GoCardlessEnterprise\Model\Mandate
      */
     public function isActive()
     {
-        return !in_array($this->getStatus(), ['failed', 'cancelled']);
+        return in_array($this->getStatus(), MandateState::getActiveStates());
     }
 }

--- a/src/Enum/MandateState.php
+++ b/src/Enum/MandateState.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lendable\GoCardlessEnterpriseBundle\Enum;
+
+class MandateState
+{
+    const ACTIVE = 'active';
+    const CANCELLED = 'cancelled';
+    const EXPIRED = 'expired';
+    const FAILED = 'failed';
+    const PENDING_SUBMISSION = 'pending_submission';
+    const SUBMITTED = 'submitted';
+
+    public static function getActiveStates(): array
+    {
+        return [
+            self::ACTIVE,
+            self::PENDING_SUBMISSION,
+            self::SUBMITTED,
+        ];
+    }
+}


### PR DESCRIPTION
• Add the mandate state enum
• Update mandate `isActive` method so it checks the set of `active` states instead of accepting all that is not canceled or failed as there is i.e. `expired` state that should not indicate that the mandate is active